### PR TITLE
chef: Use Barclamp::Inventory.Network objects

### DIFF
--- a/chef/cookbooks/hyperv/recipes/config_neutron.rb
+++ b/chef/cookbooks/hyperv/recipes/config_neutron.rb
@@ -24,7 +24,8 @@ else
 end
 Chef::Log.info("Neutron server at #{neutron_server_host}")
 
-vlan_start = node[:network][:networks][:nova_fixed][:vlan]
+fixed_net_def = Barclamp::Inventory.get_network_definition(node, "nova_fixed")
+vlan_start = fixed_net_def["vlan"]
 num_vlans = neutron_server[:neutron][:num_vlans]
 vlan_end = [vlan_start + num_vlans - 1, 4094].min
 

--- a/chef/cookbooks/hyperv/recipes/setup_networking.rb
+++ b/chef/cookbooks/hyperv/recipes/setup_networking.rb
@@ -1,8 +1,10 @@
 raise unless node[:platform_family] == "windows"
 
+admin_net = Barclamp::Inventory.get_network_by_type(node, "admin")
+
 powershell "configure_networking" do
   code <<-EOH
-  Rename-NetAdapter -Name (Get-NetIPAddress -IPAddress "#{node[:crowbar][:network][:admin][:address]}").InterfaceAlias -NewName "Management"
+  Rename-NetAdapter -Name (Get-NetIPAddress -IPAddress "#{admin_net.address}").InterfaceAlias -NewName "Management"
   $VSwitchList = Get-VMSwitch
   $SwitchConfigured = $false
 


### PR DESCRIPTION
We do this instead of accessing attributes, in order to centralize the
location of the network definitions, so it can be changed.

Should go with https://github.com/crowbar/crowbar-core/pull/510
